### PR TITLE
fix(navbar): sync dropdown color with navbar via design token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # maha-pranalika-frontend
+
+## 🎨 Design Tokens  
+
+Colors and other style constants must be rendered in `design-tokens.css`.  
+
+**Colors:**  
+- `--color-accent`: Orange (#f26522) – used in navbar and dropdown menus.  
+
+**How to use:**  
+```css
+.class {
+  background-color: var(--color-accent);
+}

--- a/maha-pranalika/src/App.jsx
+++ b/maha-pranalika/src/App.jsx
@@ -1,4 +1,5 @@
 import './App.css'
+import './styles/design-tokens.css'
 import Layout from './layout/Layout'
 import AppRoutes from './routes/AppRoutes'
 

--- a/maha-pranalika/src/components/Navbar.css
+++ b/maha-pranalika/src/components/Navbar.css
@@ -12,7 +12,7 @@
 
   }
   .nav {
-    background-color: #f26522;
+    background-color: var(--color-accent);
     font-family: Arial, sans-serif;
     padding-left: 50px;
     padding-top:10px;
@@ -53,18 +53,21 @@
     position: absolute;
     color: black;
     min-width: 200px;
-    background-color: white;
+    background-color: var(--color-accent);
     top: 100%;
     left: 0;
     z-index: 1;
   }
   
+.dropdown-content li::marker {
+  color: #fff;
+}
+
   .dropdown-content li span {
-    color: black;
+    color: white;
     padding: 12px 16px;
     font-weight: 500;
     display: block;
-    background-color: white;
   }
   
  

--- a/maha-pranalika/src/styles/design-tokens.css
+++ b/maha-pranalika/src/styles/design-tokens.css
@@ -1,0 +1,3 @@
+:root {
+  --color-accent: #f26522;
+}


### PR DESCRIPTION
- Add --color-accent in design-tokens.css
- Update dropdown styles to use the token
- Document tokens in README

Closes #11 